### PR TITLE
Add stress test and fix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ scheduler.enqueue(timeToDeliver, new ClientMessage("string client", "final-topic
 ```
 
 The message will be delivered never before the `timeToDeliver` instant, but there are no guarantees over the exact
-timing. Actual delivery delays depend on factors like service pressure or network latency.
+timing. Actual delivery delays depend on factors like service pressure, network latency and the finer granularity
+topic available. Because we can't loose messages, we also can't process them out of order and every message must
+respect the hold time associated with every topic.
 
 The client application can expect a message to be enqueued on `final-topic` topic with an internal id and the bytes
 of the `payload` string.
@@ -41,6 +43,14 @@ A custom error handler can be provided so that client applications can react to 
 handler only logs failures. **Messages with error aren't retried**. 
 
 More advanced error handling is planned, but not yet available. Will depend on what is requested. 
+
+#### At least once semantics
+
+I'm aiming at **at least once** semantics for the delivery system, ensuring every message is delivered.
+
+Like every Kafka application, it is very difficult to ensure exactly one semantics. There are are some statefull
+ objects (mainly kafka) and intricate moving parts to manage. I'll try to avoid this, but I can't guarantee it.
+Nevertheless, if receiving duplicate messages is a problem, the final topic consumers should expect them.
 
 ## Roadmap
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>scheduler</artifactId>
         <groupId>pt.pak3nuh.messaging.kafka</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/Scheduler.java
+++ b/api/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/Scheduler.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 /**
  * <p>A message delivery system with scheduling capabilities.</p>
  * <p>The delivery semantics are just an estimation and not an exact promise. The actual delivery time depends
- * on external factors like latency or service pressure.</p>
+ * on external factors like latency or service pressure and the {@link Scheduler#granularityInSeconds()}.</p>
  * <p>The consumer on the {@link ClientMessage#getDestination()} topic will receive a message with a generated
  * {@link String} id and the array of bytes in the {@link ClientMessage#getContent()}.</p>
  */
@@ -24,6 +24,11 @@ public interface Scheduler extends AutoCloseable {
 
     /**
      * <p>Returns in seconds the finer granularity available on the scheduler.</p>
+     * <p>This granularity has direct impact over the delay a message can have relative to the expected
+     * delivery time.</p>
+     * <p>Lets say we have 60 seconds of granularity and enqueue 2 messages, one to deliver after 50 seconds, and
+     * another to deliver after 30 seconds. If both messages end up in the same partition, the second message will only
+     * be delivered after the first because we need to process them in serial, to avoid loosing messages.</p>
      * @return the finer available granularity between schedules.
      */
     long granularityInSeconds();

--- a/api/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/SchedulerException.java
+++ b/api/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/SchedulerException.java
@@ -2,11 +2,24 @@ package pt.pak3nuh.messaging.kafka.scheduler;
 
 public class SchedulerException extends RuntimeException {
 
-    public SchedulerException(String message) {
-        super(message);
+    private final boolean isFatal;
+
+    public SchedulerException(boolean isFatal) {
+        super();
+        this.isFatal = isFatal;
     }
 
     public SchedulerException(Exception cause) {
         super(cause);
+        this.isFatal = false;
+    }
+
+    public SchedulerException(String message, Exception cause) {
+        super(message, cause);
+        this.isFatal = false;
+    }
+
+    public boolean isFatal() {
+        return isFatal;
     }
 }

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>scheduler</artifactId>
         <groupId>pt.pak3nuh.messaging.kafka</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>scheduler</artifactId>
         <groupId>pt.pak3nuh.messaging.kafka</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/Topic.java
+++ b/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/Topic.java
@@ -1,8 +1,17 @@
 package pt.pak3nuh.messaging.kafka.scheduler;
 
+import pt.pak3nuh.messaging.kafka.scheduler.producer.ProducerClosedException;
+
 /**
  * Represents a topic with message production capabilities
  */
 public interface Topic {
-    void send(InternalMessage content);
+    /**
+     * Sends a message to an intermediate topic or the final topic.
+     * @param content The message to enqueue
+     * @throws SchedulerException If the message couldn't be sent to the destination topic.
+     * <p>If the producer has been closed, a {@link ProducerClosedException} is thrown, all other exceptions
+     * are wrapped into {@link SchedulerException}.</p>
+     */
+    void send(InternalMessage content) throws SchedulerException;
 }

--- a/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/consumer/Consumer.java
+++ b/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/consumer/Consumer.java
@@ -5,18 +5,22 @@ import pt.pak3nuh.messaging.kafka.scheduler.InternalMessage;
 import java.time.Instant;
 
 /**
- * <p>Consumes the records over a kafka topic and hides partition pausing mechanics.</p>
- * <p>This consumer is designed to work with the default threading model for kafka consumer, meaning not concurrent.</p>
+ * <p>Consumes the records over a kafka topic and hides pausing and seeking mechanics.</p>
+ * <p>This consumer is designed to work with the default threading model for kafka consumer, meaning not concurrent.
+ * It should also be used like a log, meaning you process a record, mark it as processed and move to the next.</p>
  * <p>All the operations submitted to kafka are synchronous.</p>
  */
 public interface Consumer extends AutoCloseable {
     /**
-     * Gets an iterable of records
+     * Gets an iterable of records.
+     * <p>If it is the first time, then it will delegate to the kafka consumer settings, if its not the first time
+     * then the next records should be the ones after the last {@link #commit(Record)}.</p>
      */
     Iterable<Record> poll();
 
     /**
-     * Submits the offsets to kafka and marks the record as processed.
+     * <p>Submits the offsets to kafka, marking the record as processed, and ensures the next {@link #poll()} call
+     * will return only newer records than {@code record}.</p>
      */
     void commit(Record record);
 

--- a/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/producer/ProducerClosedException.java
+++ b/core/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/producer/ProducerClosedException.java
@@ -1,0 +1,9 @@
+package pt.pak3nuh.messaging.kafka.scheduler.producer;
+
+import pt.pak3nuh.messaging.kafka.scheduler.SchedulerException;
+
+public final class ProducerClosedException extends SchedulerException {
+    public ProducerClosedException() {
+        super(true);
+    }
+}

--- a/core/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/InternalMessageFactory.java
+++ b/core/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/InternalMessageFactory.java
@@ -29,7 +29,7 @@ public final class InternalMessageFactory {
         ArrayList<InternalMessage> objects = new ArrayList<>(numberOfMessages);
         Instant delivery = Instant.now().plusSeconds(60 * minutes);
         for (int i = 0; i < numberOfMessages; i++) {
-            objects.add(create(delivery, Instant.now()));
+            objects.add(create(delivery, delivery));
         }
         return objects.stream();
     }

--- a/core/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/dispatcher/InternalThreadDispatcherTest.java
+++ b/core/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/dispatcher/InternalThreadDispatcherTest.java
@@ -114,38 +114,6 @@ class InternalThreadDispatcherTest {
         assertEquals(1, work.toProcess.size());
     }
 
-    @Test
-    void shouldShortCircuitIfMessageIsToBeDelivered() {
-        Instant messageDeliveryTime = Instant.now();
-        InternalMessage readyMessage = create(messageDeliveryTime);
-        long seconds = DispatcherThread.secondsUntilProcess(readyMessage, Instant.MAX, messageDeliveryTime.minusSeconds(1));
-        assertTrue(seconds < 0);
-    }
-
-    @Test
-    void shouldWaitForDeliveryTime() {
-        Instant now = Instant.now();
-        Instant nowWithDelay = now.minusSeconds(5 * 60);
-        Instant deliveryTime = now.plusSeconds(1);
-        Instant creationTime = deliveryTime.plusSeconds(60);
-        InternalMessage readyMessage = create(deliveryTime, creationTime);
-        long seconds = DispatcherThread.secondsUntilProcess(readyMessage, nowWithDelay, now);
-        // difference between now and delivery time
-        assertEquals(1, seconds);
-    }
-
-    @Test
-    void shouldWaitForHoldTime() {
-        Instant now = Instant.now();
-        Instant nowWithDelay = now.minusSeconds(60);
-        Instant deliveryTime = now.plusSeconds(5);
-        Instant creationTime = nowWithDelay.plusSeconds(1);
-        InternalMessage readyMessage = create(deliveryTime, creationTime);
-        long seconds = DispatcherThread.secondsUntilProcess(readyMessage, nowWithDelay, now);
-        // difference between nowWithDelay and hold time
-        assertEquals(1, seconds);
-    }
-
     @Value
     private static class R implements Consumer.Record {
         InternalMessage message;

--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    depends_on:
+      - zookeeper
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_CREATE_TOPICS: "test:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>scheduler</artifactId>
         <groupId>pt.pak3nuh.messaging.kafka</groupId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,7 +22,7 @@
             <groupId>org.mandas.kafka</groupId>
             <artifactId>kafka-cluster-unit</artifactId>
             <version>${kafka-cluster-unit.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/ConnectLiveKafka.java
+++ b/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/ConnectLiveKafka.java
@@ -1,0 +1,17 @@
+package pt.pak3nuh.messaging.kafka.scheduler;
+
+import java.time.Instant;
+
+public final class ConnectLiveKafka {
+    public static void main(String[] args) {
+        SchedulerBuilder builder = new SchedulerBuilder("localhost:9092").addScheduleMinutes(1)
+                .addScheduleMinutes(5)
+                .addScheduleMinutes(20)
+                .appName("blah");
+
+        try(Scheduler scheduler = builder.build()) {
+            ClientMessage clientMessage = new ClientMessage("blah-app", "destination-topic", new byte[0]);
+            scheduler.enqueue(Instant.now().plusSeconds(120), clientMessage);
+        }
+    }
+}

--- a/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/MemoryClusterFactory.java
+++ b/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/MemoryClusterFactory.java
@@ -1,0 +1,19 @@
+package pt.pak3nuh.messaging.kafka.scheduler;
+
+import org.mandas.kafka.KafkaCluster;
+
+import java.util.HashMap;
+
+public final class MemoryClusterFactory {
+    private MemoryClusterFactory() {
+    }
+
+    public static KafkaCluster create() {
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put("auto.create.topics.enable", true);
+        return KafkaCluster.builder()
+                .withZookeeper("127.0.0.1", 2181, 2182)
+                .withBroker(1, "127.0.0.1", 9092, 9093, properties)
+                .build();
+    }
+}

--- a/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/MessageWaiter.java
+++ b/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/MessageWaiter.java
@@ -1,0 +1,205 @@
+package pt.pak3nuh.messaging.kafka.scheduler;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public final class MessageWaiter implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageWaiter.class);
+    private final String destinationTopic;
+    private final String servers;
+    private final Duration arrivalDelta;
+    private final Scheduler scheduler;
+    private final CompletableFuture<Result> future = new CompletableFuture<>();
+    private final Map<String, Data> enqueued;
+    private volatile boolean closed = false;
+
+    public MessageWaiter(String destinationTopic, String servers, Duration arrivalDelta, Scheduler scheduler,
+                         int recordSize) {
+        this.destinationTopic = destinationTopic;
+        this.servers = servers;
+        this.arrivalDelta = arrivalDelta;
+        this.scheduler = scheduler;
+        enqueued = new ConcurrentHashMap<>(recordSize);
+    }
+
+    public void enqueueMessage(String data, Instant arrival) {
+        LOGGER.trace("Enqueuing data {} at {}", data, arrival);
+        ClientMessage clientMessage = new ClientMessage("message-waiter", destinationTopic, data.getBytes());
+        scheduler.enqueue(arrival, clientMessage);
+        enqueued.put(data, new Data(data, arrival));
+    }
+
+    public Result waitForTermination(Instant timeout) throws ExecutionException, InterruptedException {
+        KafkaThread thread = new KafkaThread(timeout);
+        thread.start();
+        return future.get();
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    private class KafkaThread extends Thread {
+
+        private final KafkaConsumer<byte[], byte[]> consumer;
+        private final Instant timeout;
+        private final Result result = new Result(enqueued);
+        private final int numMessages = enqueued.size();
+
+        private KafkaThread(Instant timeout) {
+            setDaemon(true);
+            this.timeout = timeout;
+            Properties properties = new Properties();
+            properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, servers);
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, "some test group");
+            properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+            properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+            consumer = new KafkaConsumer<>(properties);
+        }
+
+        @Override
+        public void run() {
+            try {
+                consumer.subscribe(Collections.singleton(destinationTopic));
+                pollLoop();
+            } catch (Throwable ex) {
+                result.throwable = ex;
+            } finally {
+                future.complete(result);
+                consumer.close();
+            }
+        }
+
+        private void pollLoop() throws InterruptedException, TimeoutException {
+            while (!closed) {
+                if (result.success == numMessages) {
+                    future.complete(result);
+                    return;
+                }
+                checkInterrupted();
+                checkTimeout();
+                consumer.poll(Duration.ofSeconds(3)).forEach(record -> {
+                    Instant now = Instant.now();
+                    result.messagesReceived++;
+                    String key = new String(record.value());
+                    LOGGER.debug("Received key {}", key);
+                    Data data = enqueued.get(key);
+                    if (null == data) {
+                        LOGGER.error("Non expected data {}", key);
+                        result.unexpectedData++;
+                        return;
+                    }
+                    data.markArrival();
+                    if (data.arrivedAtDelta.size() == 1) {
+                        if (now.isAfter(data.expectedAt.plus(arrivalDelta))) {
+                            LOGGER.error("Message with id {} expected at {} arrived at {}", data.id, data.expectedAt, now);
+                            result.delayed++;
+                        } else {
+                            result.success++;
+                        }
+                    } else {
+                        LOGGER.error("Key {} received in duplicate", key);
+                        result.duplicated++;
+                    }
+                });
+            }
+        }
+
+        private void checkTimeout() throws TimeoutException {
+            if (Instant.now().isAfter(timeout)) {
+                throw new TimeoutException("Wait timed out, remaining " + enqueued);
+            }
+        }
+
+        private void checkInterrupted() throws InterruptedException {
+            if (isInterrupted())
+                throw new InterruptedException("Thread interrupted");
+        }
+    }
+
+    private static class Data {
+        private final String id;
+        private final Instant expectedAt;
+        private final List<Long> arrivedAtDelta = new ArrayList<>();
+
+        private Data(String id, Instant expectedAt) {
+            this.id = id;
+            this.expectedAt = expectedAt;
+        }
+
+        public void markArrival() {
+            final long arrivalSeconds = expectedAt.until(Instant.now(), ChronoUnit.SECONDS);
+            arrivedAtDelta.add(arrivalSeconds);
+        }
+
+        @Override
+        public String toString() {
+            return "Data{" +
+                    "id='" + id + '\'' +
+                    ", expectedAt=" + expectedAt +
+                    ", arrivedAtDelta=" + arrivedAtDelta +
+                    '}';
+        }
+    }
+
+    public static class Result {
+        private int success;
+        private int duplicated;
+        private int delayed;
+        private int unexpectedData;
+        private int messagesReceived;
+        public final Map<String, Data> originalData;
+        public Throwable throwable;
+
+        public Result(Map<String, Data> originalData) {
+            this.originalData = originalData;
+        }
+
+        @Override
+        public String toString() {
+            return "Result{" +
+                    "success=" + success +
+                    ", duplicated=" + duplicated +
+                    ", delayed=" + delayed +
+                    ", unexpectedData=" + unexpectedData +
+                    ", lateValuesMean=" + lateValuesMean() +
+                    '}';
+        }
+
+        private double lateValuesMean() {
+            return originalData.values()
+                    .stream().flatMap(it -> it.arrivedAtDelta.stream())
+                    .filter(it -> it > 0)
+                    .mapToLong(it -> it)
+                    .summaryStatistics()
+                    .getAverage();
+        }
+
+        public boolean isSuccess() {
+            return success == originalData.size()
+                    && messagesReceived == success
+                    && duplicated == 0
+                    && delayed == 0
+                    && unexpectedData == 0
+                    && throwable == null;
+        }
+    }
+}

--- a/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/StressTest.java
+++ b/integration-test/src/main/java/pt/pak3nuh/messaging/kafka/scheduler/StressTest.java
@@ -1,0 +1,102 @@
+package pt.pak3nuh.messaging.kafka.scheduler;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.mandas.kafka.KafkaCluster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+public final class StressTest {
+
+    public static final Random RANDOM = new Random();
+    private static final KafkaCluster cluster = MemoryClusterFactory.create();
+    private static final Logger LOGGER = LoggerFactory.getLogger(StressTest.class);
+
+    public static void main(String[] args) throws Throwable {
+        withMemoryKafka();
+//        withLiveCluster();
+    }
+
+    private static void withLiveCluster() throws Throwable {
+        final Properties props = new Properties();
+        final String brokers = "localhost:9092";
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        final AdminClient adminClient = AdminClient.create(props);
+//        deleteAll(adminClient);
+        final Set<String> existingTopics = adminClient.listTopics().names().get();
+        try {
+            runTest(brokers);
+        } finally {
+            final Set<String> currentTopics = adminClient.listTopics().names().get();
+            final Set<String> toRemove = currentTopics.stream().filter(it -> !existingTopics.contains(it)).collect(Collectors.toSet());
+            adminClient.deleteTopics(toRemove).all().get();
+            adminClient.close();
+        }
+    }
+
+    private static void deleteAll(AdminClient client) throws ExecutionException, InterruptedException {
+        final Set<String> existingTopics = client.listTopics().names().get();
+        client.deleteTopics(existingTopics).all().get();
+    }
+
+    private static void withMemoryKafka() throws Throwable {
+        String brokers = cluster.brokers();
+        cluster.start();
+        try {
+            runTest(brokers);
+        } finally {
+            cluster.shutdown();
+        }
+    }
+
+    private static void runTest(String brokers) throws Throwable {
+        SchedulerBuilder builder = new SchedulerBuilder(brokers).appName("stress-test-")
+                .addScheduleMinutes(1)
+                .addScheduleMinutes(3)
+                .addScheduleMinutes(5)
+                .addScheduleMinutes(10);
+
+        final int numMessages = 1_000_000;
+        final int testDurationMinutes = 10;
+
+        try (Scheduler scheduler = builder.build()) {
+            final Duration deliveryDelta = Duration.ofSeconds(scheduler.granularityInSeconds() + 10);
+            final Instant maxMessageDelivery = Instant.now().plus(Duration.ofMinutes(testDurationMinutes));
+            final String destinationTopic = "stress-test-destination";
+
+            try (MessageWaiter waiter = new MessageWaiter(destinationTopic, brokers, deliveryDelta, scheduler, numMessages)) {
+                scheduler.start();
+                for (int i = 0; i < numMessages; i++) {
+                    waiter.enqueueMessage(String.valueOf(i), randomArrival(maxMessageDelivery));
+                }
+
+                final MessageWaiter.Result result = waiter.waitForTermination(maxMessageDelivery.plus(deliveryDelta));
+                if (result.isSuccess()) {
+                    LOGGER.info("All messages delivered on time");
+                } else {
+                    LOGGER.error("Not all data was delivered as expected {}", result);
+                    throw new IllegalStateException("Result was not successful");
+                }
+            }
+        }
+    }
+
+    private static Instant randomArrival(Instant timeout) {
+        final Instant now = Instant.now();
+        final int seconds = (int) now.until(timeout, ChronoUnit.SECONDS);
+        final Instant arrival = timeout.minusSeconds(RANDOM.nextInt(seconds));
+        if (arrival.isBefore(now) || arrival.isAfter(timeout)) {
+            throw new IllegalStateException("Wrong random arrival");
+        }
+        return arrival;
+    }
+}

--- a/integration-test/src/main/resources/log4j2.xml
+++ b/integration-test/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %c{1.} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="pt.pak3nuh" level="trace"/>
+        <Logger name="org.apache.zookeeper" level="warn"/>
+        <Logger name="org.apache.kafka" level="warn"/>
+        <Logger name="kafka" level="warn"/>
+    </Loggers>
+</Configuration>

--- a/integration-test/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/MessageEnqueueingTest.java
+++ b/integration-test/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/MessageEnqueueingTest.java
@@ -15,7 +15,6 @@ import org.mandas.kafka.KafkaCluster;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
@@ -23,16 +22,7 @@ import java.util.concurrent.TimeoutException;
 public final class MessageEnqueueingTest {
 
     private static final String TOPIC = "destination";
-    private static final KafkaCluster cluster;
-
-    static {
-        HashMap<String, Object> properties = new HashMap<>();
-        properties.put("auto.create.topics.enable", true);
-        cluster = KafkaCluster.builder()
-                .withZookeeper("127.0.0.1", 2181, 2182)
-                .withBroker(1, "127.0.0.1", 9092, 9093, properties)
-                .build();
-    }
+    private static final KafkaCluster cluster = MemoryClusterFactory.create();
 
     @BeforeAll
     static void beforeAll() {

--- a/integration-test/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/SchedulerCreationTest.java
+++ b/integration-test/src/test/java/pt/pak3nuh/messaging/kafka/scheduler/SchedulerCreationTest.java
@@ -9,10 +9,7 @@ import org.mandas.kafka.KafkaCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public final class SchedulerCreationTest {
 
-    private static final KafkaCluster cluster = KafkaCluster.builder()
-            .withZookeeper("127.0.0.1", 10000, 10001)
-            .withBroker(1, "127.0.0.1", 10002, 10003)
-            .build();
+    private static final KafkaCluster cluster = MemoryClusterFactory.create();
 
     @BeforeAll
     static void beforeAll() {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>pt.pak3nuh.messaging.kafka</groupId>
     <artifactId>scheduler</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Fixes duplicated message problem and refines resource closing
On close, the consumer would still iterate through all the messages it had in memory.
Reverts documentation to mention finer granularity topic
Fixes skipping messages on error cases.
If a consumer couldn't process a message for some reason, the whole batch
would be lost.
Since the message consumption should be ordered, we can seek the consumer
to the same offset on commit and ensure the next poll is on par with the server.